### PR TITLE
feat: Add `basics.pronouns`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -6,6 +6,17 @@
       "type": "string",
       "description": "Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04",
       "pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
+    },
+    "pronounSimple": {
+      "type": "string",
+      "description": "e.g. they/them/theirs"
+    },
+    "pronounList": {
+      "type": "array",
+      "description": "An array containing your preferred pronouns, e.g. ['they', 'them', 'theirs']",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "properties": {
@@ -37,6 +48,38 @@
         "phone": {
           "type": "string",
           "description": "Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"
+        },
+        "pronouns": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/pronounSimple"
+            },
+            {
+              "$ref": "#/definitions/pronounList"
+            },
+            {
+              "type": "object",
+              "description": "pronoun string + link",
+              "additionalProperties": true,
+              "properties": {
+                "content": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/pronounSimple"
+                    },
+                    {
+                      "$ref": "#/definitions/pronounList"
+                    }
+                  ]
+                },
+                "url": {
+                  "type": "string",
+                  "description": "e.g. http://my.pronoun.is/they",
+                  "format": "uri"
+                }
+              }
+            }
+          ]
         },
         "url": {
           "type": "string",

--- a/test/__test__/basics.json
+++ b/test/__test__/basics.json
@@ -65,6 +65,42 @@
       "url": null
     }
   },
+  "pronounsSimpleValid": {
+    "basics": {
+      "pronouns": "he/him"
+    }
+  },
+  "pronounsSimpleInvalid": {
+    "basics": {
+      "pronouns": null
+    }
+  },
+  "pronounsListValid": {
+    "basics": {
+      "pronouns": ["they", "them"]
+    }
+  },
+  "pronounsListInvalid": {
+    "basics": {
+      "pronouns": [null]
+    }
+  },
+  "pronounsObjectValid": {
+    "basics": {
+      "pronouns": {
+        "content": "she/her",
+        "url": "https://pronouns.cc/pronouns/she/her/her/hers/herself"
+      }
+    }
+  },
+  "pronounsObjectInvalid": {
+    "basics": {
+      "pronouns": {
+        "content": null,
+        "url": "https://pronouns.cc/pronouns/she/her/her/hers/herself"
+      }
+    }
+  },
   "summaryValid": {
     "basics": {
       "summary": "Richard hails from Tulsa. He has earned degrees from the University of Oklahoma and Stanford."

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -114,6 +114,55 @@ test('basics.url - invalid', (t) => {
   t.end();
 });
 
+test("basics.pronouns simple - valid", (t) => {
+  validate(fixtures.pronounsSimpleValid, (err, valid) => {
+    t.equal(err, null, "err should be null");
+    t.true(valid, "valid is true");
+  });
+  t.end();
+});
+
+test("basics.pronouns simple - invalid", (t) => {
+  validate(fixtures.pronounsSimpleInvalid, (err, valid) => {
+    t.notEqual(err, null, "err should contain an error");
+    t.false(valid, "valid is false");
+  });
+  t.end();
+});
+
+test("basics.pronouns list - valid", (t) => {
+  validate(fixtures.pronounsListValid, (err, valid) => {
+    t.equal(err, null, "err should be null");
+    t.true(valid, "valid is true");
+  });
+  t.end();
+});
+
+test("basics.pronouns list - invalid", (t) => {
+  validate(fixtures.pronounsListInvalid, (err, valid) => {
+    t.notEqual(err, null, "err should contain an error");
+    t.false(valid, "valid is false");
+  });
+  t.end();
+});
+
+test("basics.pronouns object - valid", (t) => {
+  validate(fixtures.pronounsObjectValid, (err, valid) => {
+    t.equal(err, null, "err should be null");
+    t.true(valid, "valid is true");
+  });
+  t.end();
+});
+
+test("basics.pronouns object - invalid", (t) => {
+  validate(fixtures.pronounsObjectInvalid, (err, valid) => {
+    t.notEqual(err, null, "err should contain an error");
+    t.false(valid, "valid is false");
+  });
+  t.end();
+});
+
+
 test('basics.summary - valid', (t) => {
   validate(fixtures.summaryValid, (err, valid) => {
     t.equal(err, null, 'err should be null');


### PR DESCRIPTION
Based on @veeara282's work on https://github.com/jsonresume/resume-schema/pull/325. I lifted the schema verbatim, and added unit tests.

# Motivation

Why should a JSON résumé schema facilitate a `pronouns` field:
- People aren't always accurately gendered by their photo. Whether a person "looks like a man" varies by culture and circumstance. If you didn't know this, you need to get out more.
- Recruiters and others reading résumés should not be expected to guess an applicant's forms of address on sight. (That's just rude.)
- It's cool to normalize providing a simple detail that answers questions like "how should people refer to this person in a respectful manner?"
- Adding the field is super easy, barely an inconvenience.
- The field may be optional. Users don't have to declare their forms of address if they do not want to.
- Declaring one's own forms of address hurts no one.
- [It's becoming more common to add pronouns to résumé documents](https://www.themuse.com/advice/pronouns-on-resume).
- Standardizing this field in the JSON schema helps theme developers to adopt the field more readily, rather than forcing them each to guess where users might put the field in custom configurations. ([Somewhere in `meta`](https://github.com/jsonresume/resume-schema/issues/447#issuecomment-1824702765), perhaps? Are we talking `meta.pronouns`, or something more structured like `meta.basics.pronouns`? I get the impression that `meta` is more about the _document_ than the _author_, so `basics` would be a better spot for the author's forms of address, I think.)
- It's just plain polite to refer to people the way they want to be referred to, such as by their own name, or by the appropriate title. Pronouns are even more common than formal titles, since everyone gets referred to in the third person at some point.
- Pronouns are very common. Declaring one's own forms of address (and having a simple, neutral, easy, and unobtrusive way to do so without social stigma or ridicule) eliminates a lot of extra brain steps.
- Why not add the field?

Why omit the `pronouns` field:
- The `basics` property [already](https://github.com/jsonresume/resume-schema/blob/8996c2c99426ffc2606f592aad02a9038fbde692/schema.json#L19) permits additional properties. Custom properties there already pass validation, so users ought to add their own. An ecosystem decision on the matter will surface naturally in several years or so.
- We don't know the best place for it, nor the best shape.
- @thomasdavis doesn't want to. Fair enough, it's their project I guess.

These lists are not comprehensive. I may have rendered my arguments inefficiently or veered into straw-man territory in some cases. I'm certainly biased, but I think that having a standard `pronouns` field does more good than harm.

I figure if @thomasdavis is [so adamant](https://github.com/jsonresume/resume-schema/pull/325#issuecomment-860653550) that resume-schema omit the pronouns field as a standard, then a fork will do well enough. Even if it's only me using this fork, this is a fun project for me, and it makes the tooling around my own résumé more complete.

These proposed changes are flexible enough for most users to declare their forms of third-person address. As the language evolves, so too can the schema.

Not a political stunt, only trying to be helpful.

See also discussion at https://github.com/jsonresume/resume-schema/issues/324, https://github.com/jsonresume/resume-schema/issues/447, and https://github.com/jsonresume/resume-schema/issues/475.