### PR TITLE
feat: Add `Promise`-compatible interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ try {
 Simplified:
 
 ```js
-const fs = require("fs");
+const fs = require("node:fs");
 const resumeSchema = require("@averagehelper/resume-schema");
 const resume = JSON.parse(fs.readFileSync("resume.json", "utf8"));
 
@@ -62,7 +62,7 @@ const resumeObject = await resumeSchema.validated(resume); // throws if invalid
 Callback:
 
 ```js
-const fs = require("fs");
+const fs = require("node:fs");
 const resumeSchema = require("@averagehelper/resume-schema");
 const resume = JSON.parse(fs.readFileSync("resume.json", "utf8"));
 
@@ -75,10 +75,20 @@ resumeSchema.validate(resume, function (err, result) {
 });
 ```
 
+TypeScript compatible:
+
+```ts
+import fs from "node:fs";
+import { validated } from "@averagehelper/resume-schema";
+const resume = JSON.parse(fs.readFileSync("resume.json", "utf8"));
+
+const resumeObject = await validated(resume); // throws if invalid
+```
+
 The JSON Resume schema is available from:
 
 ```js
-require("@averagehelper/resume-schema").schema;
+import { schema } from "@averagehelper/resume-schema";
 ```
 
 ### Contribute

--- a/README.md
+++ b/README.md
@@ -15,48 +15,64 @@ My goals for this project:
 - [x] Basic TypeScript declarations around exported structures
 - [x] Generate a TypeScript interface from the JSON schema, to make generic theme templates easier to construct
 - [x] Port to TypeScript
-- [ ] Clean up and update the changelog, perhaps using the [keep a changelog](https://keepachangelog.com) standard.
+- [x] Add a `Promise`-compatible interface for `validate`
+- [ ] Clean up and update the changelog, perhaps using the [keep a changelog](https://keepachangelog.com) standard
 - [ ] Simplify unit tests. Surely there's a way to generate each valid/invalid test case from the existing well-labeled valid/invalid test fixtures!
-- [ ] Add a `Promise`-compatible interface for `validate`
 - [ ] Build both legacy CJS and modern ESM bundles
 - [ ] Switch to tab indentation [for accessibility](https://www.reddit.com/r/javascript/comments/c8drjo/nobody_talks_about_the_real_reason_to_use_tabs/)
 
 I might add more as ideas come to me. I plan to open upstream pull requests once in a while. I'm not sure all of my changes will make it upstream, but a gal can try!
 
-A read-only mirror exists at [my Forgejo instance](https://git.average.name/AverageHelper/resume-schema).
+A read-only mirror exists at [my git forge](https://git.average.name/AverageHelper/resume-schema).
 
 ### Getting started
 
+This package requires Node 10 or newer.
+
 ```sh
-npm install --save @averagehelper/resume-schema
+npm install @averagehelper/resume-schema
 ```
 
-To use
+### Usage
+
+Basic:
 
 ```js
 const resumeSchema = require("@averagehelper/resume-schema");
-resumeSchema.validate(
-  { name: "Thomas" },
-  function (err, report) {
-    if (err) {
-      console.error("The resume was invalid:", err);
-      return;
-    }
-    console.log("Resume validated successfully:", report);
-  },
-  function (err) {
-    console.error("The resume was invalid:", err);
-  }
-);
+const resume = JSON.parse(fs.readFileSync("resume.json", "utf8"));
+
+try {
+  await resumeSchema.validate(resume);
+  console.log("Resume validated successfully!");
+} catch (error) {
+  console.error("The resume was invalid:", error);
+}
 ```
 
-More likely
+Simplified:
 
 ```js
-var fs = require("fs");
-var resumeSchema = require("@averagehelper/resume-schema");
-var resumeObject = JSON.parse(fs.readFileSync("resume.json", "utf8"));
-resumeSchema.validate(resumeObject);
+const fs = require("fs");
+const resumeSchema = require("@averagehelper/resume-schema");
+const resume = JSON.parse(fs.readFileSync("resume.json", "utf8"));
+
+const resumeObject = await resumeSchema.validated(resume); // throws if invalid
+```
+
+Callback:
+
+```js
+const fs = require("fs");
+const resumeSchema = require("@averagehelper/resume-schema");
+const resume = JSON.parse(fs.readFileSync("resume.json", "utf8"));
+
+resumeSchema.validate(resume, function (err, result) {
+  if (err) {
+    console.error("The resume was invalid:", error);
+  } else {
+    console.log("Resume validated successfully:", result);
+  }
+});
 ```
 
 The JSON Resume schema is available from:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@averagehelper/resume-schema",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@averagehelper/resume-schema",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "z-schema": "^4.2.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@averagehelper/resume-schema",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "JSON Resume Schema, with extras",
   "main": "validator.js",
   "types": "validator.d.ts",

--- a/test/work.spec.js
+++ b/test/work.spec.js
@@ -1,5 +1,5 @@
 var test = require('tape');
-var { validate } = require('../validator');
+var { validate, validated } = require('../validator');
 const fixtures = require('./__test__/work.json');
 
 test('work - valid', (t) => {
@@ -15,6 +15,46 @@ test('work - invalid', (t) => {
     t.notEqual(err, null, 'err should contain an error');
     t.false(valid, 'valid is false');
   });
+  t.end();
+});
+
+test('work - valid async', async (t) => {
+  try {
+    await validate(fixtures.workValid);
+    t.pass('valid is true');
+  } catch (err) {
+    t.fail('err should be null', err);
+  }
+  t.end();
+});
+
+test('work - invalid async', async (t) => {
+  try {
+    await validate(fixtures.workInvalid);
+    t.fail('valid is false');
+  } catch (err) {
+    t.notEqual(err, null, 'err should contain an error');
+  }
+  t.end();
+});
+
+test('work - valid async simple', async (t) => {
+  try {
+    const workValid = await validated(fixtures.workValid);
+    t.deepEqual(workValid, fixtures.workValid);
+  } catch (err) {
+    t.fail('err should be null', err);
+  }
+  t.end();
+});
+
+test('work - invalid async simple', async (t) => {
+  try {
+    await validated(fixtures.workInvalid);
+    t.fail('valid is false');
+  } catch (err) {
+    t.notEqual(err, null, 'err should contain an error');
+  }
   t.end();
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
 		"useUnknownInCatchVariables": true,
 		"noUncheckedIndexedAccess": true,
 		"forceConsistentCasingInFileNames": true,
+    "typeRoots": ["./resume.d.ts"]
   },
   "include": ["*.ts"]
 }

--- a/validator.ts
+++ b/validator.ts
@@ -1,8 +1,23 @@
+import type { ResumeSchema } from './resume.d.ts';
 import ZSchema = require('z-schema');
 import schema = require('./schema.json');
 
 // Generated schema interface types
 export type * from "./resume.d.ts";
+
+type ValidateCallback = (error: unknown, result?: { valid: boolean }) => unknown;
+
+type ZSchemaCallback = (error: unknown, valid: boolean) => unknown;
+
+/**
+ * Asynchronously validates a given object against the JsonResume schema.
+ *
+ * @param resumeJson The object to validate.
+ *
+ * @throws an error if the object is invalid against the JsonResume schema.
+ * @returns A promise that resolves if the validation is successful.
+ */
+export async function validate(resumeJson: object): Promise<void>;
 
 /**
  * Asynchronously validates a given object against the JsonResume schema.
@@ -10,16 +25,53 @@ export type * from "./resume.d.ts";
  * @param resumeJson The object to validate.
  * @param callback A function that is called with the validation result.
  */
-export function validate(resumeJson: object, callback: (error: unknown, result?: { valid: boolean }) => unknown): void {
-  const callbackWrapper = function(err: unknown, valid: boolean) {
-    if(err) {
-      callback(err)
-    } else {
-      callback(null, {valid: valid});
-    }
-  }
+export function validate(resumeJson: object, callback: ValidateCallback): void;
 
-  new ZSchema({}).validate(resumeJson, schema, callbackWrapper);
+export function validate(resumeJson: object, callback?: ValidateCallback): void | Promise<void> {
+  if (callback) {
+    // Callback mode
+    const callbackWrapper: ZSchemaCallback = function (err, valid) {
+      if (err) {
+        // Invalid schema!
+        callback(err);
+      } else {
+        // Valid schema?
+        callback(null, { valid: valid });
+      }
+    }
+
+    new ZSchema({}).validate(resumeJson, schema, callbackWrapper);
+  } else {
+    // Promise mode
+    return new Promise((resolve, reject) => {
+      const callbackWrapper: ZSchemaCallback = function (err, valid) {
+        if (err) {
+          // Invalid schema!
+          reject(err);
+        } else if (!valid) {
+          // Should be impossible
+          reject(new TypeError('z-schema returned `valid: false` with no error'));
+        } else {
+          // Valid schema!
+          resolve();
+        }
+      }
+
+      new ZSchema({}).validate(resumeJson, schema, callbackWrapper);
+    });
+  }
+}
+
+/**
+ * Validates and returns résumé data from the given object.
+ *
+ * @param resumeJson The object to validate.
+ * @throws an error if the object is invalid against the JsonResume schema.
+ * @returns A promise that resolves with the validated data.
+ */
+export async function validated(resumeJson: object): Promise<ResumeSchema> {
+  await validate(resumeJson); // throws if invalid
+  return resumeJson;
 }
 
 export { schema };


### PR DESCRIPTION
### Added
- New `async` interface for `validate`.
- New `validated` function that returns a Promise with a valid résumé schema value.